### PR TITLE
Add 64-bit terraform requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the main repo for the GreenLake terraform provider which provides terraf
 
 ## Prerequisites
 
-1. Terraform version >= v0.13 [install terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+1. Terraform version >= v0.13 and 64-bit [install terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 1. An API client to authenticate against GreenLake.
 1. Terraform basics. [Terraform Introduction](https://www.terraform.io/intro/index.html)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,8 @@ Current supported services:
 - [Containers](https://github.com/HewlettPackard/hpegl-containers-terraform-resources)
 - [Metal](https://github.com/HewlettPackard/hpegl-metal-terraform-resources)
 
+This provider requires 64-bit versions of the terraform binary to work properly.
+
 Note that an API client must be used with this provider.  For information on how to
 create an API client see [here](http://www.hpe.com/info/greenlakecentral-create-api-client).
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -16,6 +16,8 @@ Current supported services:
 - [Containers](https://github.com/HewlettPackard/hpegl-containers-terraform-resources)
 - [Metal](https://github.com/HewlettPackard/hpegl-metal-terraform-resources)
 
+This provider requires 64-bit versions of the terraform binary to work properly.
+
 Note that an API client must be used with this provider.  For information on how to
 create an API client see [here](http://www.hpe.com/info/greenlakecentral-create-api-client).
 


### PR DESCRIPTION
In this PR we add a requirement to use 64-bit versions of terraform to the README and to templates/index.md.tmpl.  We regenerate the docs which has resulted in an update to docs/index.md

Signed-off-by: Eamonn O'Toole <eamonn.otoole@hpe.com>