### PR TITLE
Bump the version of Go in CI to 1.20

### DIFF
--- a/.github/workflows/acceptance_caas.yaml
+++ b/.github/workflows/acceptance_caas.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.19' ]
+        go: [ '1.20' ]
     name: Acceptance Tests
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/acceptance_vmaas.yaml
+++ b/.github/workflows/acceptance_vmaas.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.19' ]
+        go: [ '1.20' ]
     name: Acceptance Tests
     steps:
       - name: Checkout workspace
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: Install dependencies
         run: |
           sudo apt-get install -y wget jq

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.19' ]
+        go: [ '1.20' ]
     name: Go ${{ matrix.go }} CI test
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.19' ]
+        go: [ '1.20' ]
     name: Linting
     steps:
       - uses: actions/checkout@v4

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,7 +19,7 @@ fmt:
 	gofmt -s -w $(GOFMT_FILES)
 
 tools:
-	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
+	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
 
 lint: tools
 	@echo "==> Checking source code against linters..."

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/HPE/terraform-provider-hpegl
 
-go 1.19
+go 1.20
 
 require (
 	github.com/HewlettPackard/hpegl-containers-terraform-resources v0.0.11


### PR DESCRIPTION
The updated metal provider requires go 1.20 because it is now using 'errors.Join' which does not exist in earlier versions.