### PR TITLE
Bump golangci-lint version to v1.55.0

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,7 +19,7 @@ fmt:
 	gofmt -s -w $(GOFMT_FILES)
 
 tools:
-	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
+	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
 
 lint: tools
 	@echo "==> Checking source code against linters..."


### PR DESCRIPTION
The current version of golangci-lint does not work with go 1.20. It raises the following error:

 can't run linter goanalysis_metalinter: goanalysis_metalinter:
 buildir: package "netip" (isInitialPkg: false, needAnalyzeSource:
 true): in net/netip.AddrFromSlice: cannot convert Load <[]byte> t0
 ([]byte) to [4]byte

Bump to version v1.55.0 which avoids this error. This will allow us to update to go 1.20 in a follow on change.