### PR TITLE
Fix default data-source and resource doc templates

### DIFF
--- a/templates/data-sources.md.tmpl
+++ b/templates/data-sources.md.tmpl
@@ -11,7 +11,7 @@ description: |-
 {{ if .HasExample -}}
 ## Example Usage
 
-{{ printf "{{tffile %q}}" .ExampleFile }}
+{{ tffile .ExampleFile }}
 {{- end }}
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -11,7 +11,7 @@ description: |-
 {{ if .HasExample -}}
 ## Example Usage
 
-{{ printf "{{tffile %q}}" .ExampleFile }}
+{{ tffile .ExampleFile }}
 {{- end }}
 
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
In this PR we update
- templates/data-sources.md.tmpl
- templates/resources.md.tmpl

To replace {{ printf "{{tffile %q}}" .ExampleFile }} with {{ tffile .ExampleFile }}.  The old version isn't handled correctly by tfplugin-docs.