### PR TITLE
Update metal client initialisation to use GLP workspace and role

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.19.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/hewlettpackard/hpegl-metal-terraform-resources v1.3.54
-	github.com/hewlettpackard/hpegl-provider-lib v0.0.15
+	github.com/hewlettpackard/hpegl-provider-lib v0.0.16
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/hewlettpackard/hpegl-metal-client v1.5.13 h1:c4Gb9Gu449LmN0eoDVTwGgkg
 github.com/hewlettpackard/hpegl-metal-client v1.5.13/go.mod h1:E72/o32a5WwVAUhXvXEUKZOGiSA84hsTS+xezFqtbgU=
 github.com/hewlettpackard/hpegl-metal-terraform-resources v1.3.54 h1:kJGLQlrqi1VxXkGvvyclt8EST38mV0WQ/+VkQh10X14=
 github.com/hewlettpackard/hpegl-metal-terraform-resources v1.3.54/go.mod h1:q1rzaxEJL+9K3/E8NzFzBq9POxOYr4kU1ePSPKJufI8=
-github.com/hewlettpackard/hpegl-provider-lib v0.0.15 h1:yDqJNUYDq37LjpwoqvNKv2RS2s5gCEL+qQ3MD0WXIdw=
-github.com/hewlettpackard/hpegl-provider-lib v0.0.15/go.mod h1:9lEPIb9rKqxZNPkwcgRN+3/rAkpyXCk3KR8GFO5xaZ4=
+github.com/hewlettpackard/hpegl-provider-lib v0.0.16 h1:d2Thflf2n4Ew+R/GbMjOuMbxVY1CJjs3htX//qTEdFg=
+github.com/hewlettpackard/hpegl-provider-lib v0.0.16/go.mod h1:9lEPIb9rKqxZNPkwcgRN+3/rAkpyXCk3KR8GFO5xaZ4=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=


### PR DESCRIPTION
In this PR we:
- update the version of hpegl-provider-lib so that gltform includes glp_workspace and glp_role
- add a new createMetalConfig function that:
  - will use the value of glp_workspace and glp_role if they are present when creating a Metal config
  - otherwise creates the Metal config as before

This is to fix errors with Metal client initialisation with GLP IAM.