### PR TITLE
Switch to Hashicorp mux library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/HewlettPackard/hpegl-vmaas-terraform-resources v0.1.27
 	github.com/golangci/golangci-lint v1.59.1
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
+	github.com/hashicorp/terraform-plugin-go v0.23.0
+	github.com/hashicorp/terraform-plugin-mux v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/hewlettpackard/hpegl-metal-terraform-resources v1.3.57
-	github.com/hewlettpackard/hpegl-provider-lib v0.0.17
+	github.com/hewlettpackard/hpegl-provider-lib v0.0.18
 )
 
 require (
@@ -114,7 +116,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.23.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -392,6 +392,8 @@ github.com/hashicorp/terraform-plugin-go v0.23.0 h1:AALVuU1gD1kPb48aPQUjug9Ir/12
 github.com/hashicorp/terraform-plugin-go v0.23.0/go.mod h1:1E3Cr9h2vMlahWMbsSEcNrOCxovCZhOOIXjFHbjc/lQ=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
+github.com/hashicorp/terraform-plugin-mux v0.16.0 h1:RCzXHGDYwUwwqfYYWJKBFaS3fQsWn/ZECEiW7p2023I=
+github.com/hashicorp/terraform-plugin-mux v0.16.0/go.mod h1:PF79mAsPc8CpusXPfEVa4X8PtkB+ngWoiUClMrNZlYo=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0 h1:kJiWGx2kiQVo97Y5IOGR4EMcZ8DtMswHhUuFibsCQQE=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0/go.mod h1:sl/UoabMc37HA6ICVMmGO+/0wofkVIRxf+BMb/dnoIg=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
@@ -404,8 +406,8 @@ github.com/hewlettpackard/hpegl-metal-client v1.5.15 h1:q6oH0SGxJBNi+LGFNlmcL8OA
 github.com/hewlettpackard/hpegl-metal-client v1.5.15/go.mod h1:E72/o32a5WwVAUhXvXEUKZOGiSA84hsTS+xezFqtbgU=
 github.com/hewlettpackard/hpegl-metal-terraform-resources v1.3.57 h1:i2Mprz2Z1kReFEcxQYR9vB99Q6SYiZXJ9ClUCcIN9Mw=
 github.com/hewlettpackard/hpegl-metal-terraform-resources v1.3.57/go.mod h1:YYnPNpb5d1sZZ8R1addCBMyjVCQ+SXG6aNSpoueD3kI=
-github.com/hewlettpackard/hpegl-provider-lib v0.0.17 h1:6sh4XjWK2hg2q5V78W4AypV0IBbDy0CpGoMfzE1CK1c=
-github.com/hewlettpackard/hpegl-provider-lib v0.0.17/go.mod h1:Bw2DhefBjqXQI6s5vBBGiWUkFz7fx4KkbGfwmo9wv3U=
+github.com/hewlettpackard/hpegl-provider-lib v0.0.18 h1:87iXgq8Oe2ebBRicL5K+HknQF9e1ce6MHfIHeTVVqlI=
+github.com/hewlettpackard/hpegl-provider-lib v0.0.18/go.mod h1:Bw2DhefBjqXQI6s5vBBGiWUkFz7fx4KkbGfwmo9wv3U=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=

--- a/internal/acceptance/acceptance-utils/provider_test.go
+++ b/internal/acceptance/acceptance-utils/provider_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Hewlett Packard Enterprise Development LP.
+// Copyright (c) 2016-2024 Hewlett Packard Enterprise Development LP.
 
 package acceptancetest
 
@@ -31,6 +31,9 @@ func testAccPreCheck(t *testing.T) {
 	// }
 }
 
+// TestProvider tests the SDK v2.0 provider.  Leaving this here for now.  We might need
+// to remove this as we add new "framework" provider code
+// TODO remove this test
 func TestProvider(t *testing.T) {
 	if err := hpegl.ProviderFunc()().InternalValidate(); err != nil {
 		t.Fatalf("%s\n", err)
@@ -38,6 +41,7 @@ func TestProvider(t *testing.T) {
 	testAccPreCheck(t)
 }
 
+// TODO remove this test
 func TestProviderInterface(t *testing.T) {
 	var _ *schema.Provider = hpegl.ProviderFunc()()
 }

--- a/internal/acceptance/simple-mux-test/provider_test.go
+++ b/internal/acceptance/simple-mux-test/provider_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 Hewlett Packard Enterprise Development LP.
+
+package simplemuxtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+
+	"github.com/HPE/terraform-provider-hpegl/internal/hpegl"
+)
+
+// TestMuxServer is a very simple sanity check on the mux server.  There doesn't seem to be
+// an equivalent of "InternalValidate" for the mux server, so this is the best we can do.
+// Note that this isn't an acceptance test, leaving it here for now.
+func TestMuxServer(t *testing.T) {
+	ctx := context.Background()
+	providers := hpegl.ProvidersForMux()
+	muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+	if err != nil {
+		t.Fatalf("Error creating MuxServer: %v", err)
+	}
+
+	// Test GetProviderSchema - this is a very simple test to make sure the mux server is working
+	_, err = muxServer.GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("Error getting provider schema: %v", err)
+	}
+}

--- a/internal/hpegl/hpegl.go
+++ b/internal/hpegl/hpegl.go
@@ -1,10 +1,11 @@
-// (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 
 package hpegl
 
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
@@ -15,8 +16,15 @@ import (
 	"github.com/HPE/terraform-provider-hpegl/internal/services/resources"
 )
 
+// ProviderFunc this is only used for the provider interface test.  Leaving it here for now
+// TODO remove this function
 func ProviderFunc() plugin.ProviderFunc {
 	return provider.NewProviderFunc(resources.SupportedServices(), providerConfigure)
+}
+
+// ProvidersForMux this is used to create a "mux" provider
+func ProvidersForMux() []func() tfprotov5.ProviderServer {
+	return provider.ProviderForMux(resources.SupportedServices(), providerConfigure)
 }
 
 func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc { // nolint staticcheck

--- a/internal/services/resources/combined.go
+++ b/internal/services/resources/combined.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 
 package resources
 
@@ -10,6 +10,9 @@ import (
 	resmetal "github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/registration"
 )
 
+// SupportedServices returns the list of supported services.
+// Note: we will need to implement a ServiceRegistration interface which doesn't have
+// SupportedResources() or SupportedDataSources() for new "framework" providers.
 func SupportedServices() []registration.ServiceRegistration {
 	return []registration.ServiceRegistration{
 		resmetal.Registration{},


### PR DESCRIPTION
In this PR we switch to using the Hashicorp mux library to build the overall hpegl provider.  This is in anticipation of including new provider code written using the Hashicorp provider framework.  The changes:
- we import hpegl-provider-lib that builds a list of providers that we can use with the mux library (v0.0.18)
- we write a new function in internal/hpegl/hpegl.go ProvidersForMux that calls hpegl-provider-lib ProviderForMux
- we adapt main.go to use the mux library
- we add a very simple test to internal/acceptance/simple-mux-test that creates a mux provider and gets its ProviderSchema to uncover any errors in the mux