### PR TITLE
updating ubuntu runner to 22.04

### DIFF
--- a/.github/workflows/acceptance_caas.yaml
+++ b/.github/workflows/acceptance_caas.yaml
@@ -13,7 +13,7 @@ env:
   HPEGL_IAM_SERVICE_URL: ${{ secrets.CAAS_HPEGL_IAM_SERVICE_URL }}
 jobs:
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         go: [ '1.20' ]

--- a/.github/workflows/acceptance_vmaas.yaml
+++ b/.github/workflows/acceptance_vmaas.yaml
@@ -14,7 +14,7 @@ env:
   HPEGL_VMAAS_SPACE_NAME: ${{ secrets.VMAAS_HPEGL_VMAAS_SPACE_NAME}}
 jobs:
   acc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         go: [ '1.20' ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: GitHub Actions CI
 on: [push, pull_request]
 jobs:
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         go: [ '1.22.5' ]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,7 +3,7 @@ name: GitHub Actions CI
 on: [push, pull_request]
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         go: [ '1.22.5' ]


### PR DESCRIPTION
We are currently getting warnings in our CI on the main branch. It seems the ubuntu 20.04 runner is being retired.

```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15.
```

This PR will bump the runners to 22.04.

Reference:
[https://github.com/actions/runner-images/issues/11101](https://github.com/actions/runner-images/issues/11101)